### PR TITLE
[breaking] Add probability to each scenario in test_scenarios and historical_scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,33 +476,37 @@ After the optional metadata keys, there are five required keys:
 
     The nominal probability of transitioning from node `from` to node `to`.
 
-- `test_scenarios::List{List{Object}}`
+- `test_scenarios::List{Object}`
 
   Scenarios to be used to evaluate a policy. `test_scenarios` is a list,
-  containing one element for each scenario in the test set. Each scenario is a
-  list of objects. Each object has two required nodes: `node::String` and
-  `support::Object`. `node` is the name of the node to visit, and `support` is
-  the realization of the random variable at that node. Note that `support` may
-  be an _out-of-sample_ realization, that is, one which is not contained in the
-  corresponding `realizations` field of the node. Testing a policy is a larger
-  topic, so we expand on it in the section [Problems, policies, and algorithms](#problems-policies-and-algorithms).
+  containing one element for each scenario in the test set. Each element is an
+  object with two fields: `probability::Number` and `scenario::List{Object}`.
+  The `probability` gives the nominal probability associated with the scenario.
+  Each `scenario` is a list of objects. Each object has two required nodes:
+  `node::String` and `support::Object`. `node` is the name of the node to visit,
+  and `support` is the realization of the random variable at that node. Note
+  that `support` may be an _out-of-sample_ realization, that is, one which is
+  not contained in the corresponding `realizations` field of the node. Testing a
+  policy is a larger topic, so we expand on it in the section
+  [Problems, policies, and algorithms](#problems-policies-and-algorithms).
 
-There is also an optional key, `historical_scenarios::List{List{Object}}`. The
+There is also an optional key, `historical_scenarios::List{Object}`. The
 value of the key is identical to `test_scenarios`, except that these scenarios
 should be any historical data that was used when first constructing the problem.
 This allows modellers to experiment with different representations of the
 underlying stochastic process.
 
 In our example, the second stage realizations have probilities of 0.6 and 0.4.
-However, there are only two `historical_scenarios`, so one may infer that
-another reasonable model would be to give probabilities of 0.5 and 0.5.
+However, there are two `historical_scenarios`, each with probability 0.5, so one
+may infer that another reasonable model would be to give the node realizations
+probabilities of 0.5 and 0.5.
 
 Providing both `realizations` and `historical_scenarios` allows us to to do two
 things:
 
-1. Solve a model _as formulated by someone else_.
-2. Experiment with different formulations of the same sequential decision
-  problem using a standard dataset.
+1. Solve a problem _as formulated by someone else_.
+2. Experiment with different formulations for the stochasticity of the same
+   underlying decision problem.
 
 For example, we can build a linear policy graph assuming that the random
 variables are stagewise independent. However, the historical data may have some

--- a/README.md
+++ b/README.md
@@ -333,25 +333,40 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
     {"from": "first_stage", "to": "second_stage", "probability": 1.0}
   ],
   "test_scenarios": [
-    [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 10.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 14.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 9.0}}
-    ]
+    {
+      "probability": 0.4,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 10.0}}
+      ]
+    }, {
+      "probability": 0.3,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 14.0}}
+      ]
+    }, {
+      "probability": 0.3,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 9.0}}
+      ]
+    }
   ],
   "historical_scenarios": [
-    [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 10.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 14.0}}
-    ]
+    {
+      "probability": 0.5,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 10.0}}
+      ]
+    }, {
+      "probability": 0.5,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 14.0}}
+      ]
+    }
   ]
 }
 ```

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .DS_Store
 Manifest.toml
 Project.toml
+sol_*.json

--- a/examples/algorithms/TwoStageBenders.jl
+++ b/examples/algorithms/TwoStageBenders.jl
@@ -37,7 +37,7 @@ struct TwoStageProblem
     first::JuMP.Model
     second::JuMP.Model
     state_variables::Set{String}
-    test_scenarios::Vector{Vector{Dict{String, Any}}}
+    test_scenarios::Vector{Dict{String, Any}}
 end
 
 """
@@ -260,7 +260,8 @@ function evaluate(
     filename::Union{Nothing, String} = nothing
 )
     solutions = Vector{Dict{String, Any}}[]
-    for scenario in scenarios
+    for s_dict in scenarios
+        scenario = s_dict["scenario"]
         @assert length(scenario) == 2
         first_sol = _solve_first_stage(problem)
         incoming_state = Dict(

--- a/examples/algorithms/TwoStageBenders.py
+++ b/examples/algorithms/TwoStageBenders.py
@@ -90,7 +90,8 @@ class TwoStageProblem:
         if scenarios is None:
             scenarios = self.data['test_scenarios']
         solutions = []
-        for scenario in scenarios:
+        for s_dict in scenarios:
+            scenario = s_dict['scenario']
             assert(len(scenario) == 2)
             first_sol = self._solve_first_stage()
             incoming_state = {
@@ -117,7 +118,7 @@ class TwoStageProblem:
     def _validate_stochoptformat(self):
         with open(self.schema_filename, 'r') as io:
             schema = json.load(io)
-        jsonschema.validate(instance = self.data, schema = schema)
+        return jsonschema.validate(instance = self.data, schema = schema)
 
     def _get_stage_names(self):
         data = self.data

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -88,24 +88,39 @@
     {"from": "first_stage", "to": "second_stage", "probability": 1.0}
   ],
   "test_scenarios": [
-    [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 10.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 14.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 9.0}}
-    ]
+    {
+      "probability": 0.4,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 10.0}}
+      ]
+    }, {
+      "probability": 0.3,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 14.0}}
+      ]
+    }, {
+      "probability": 0.3,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 9.0}}
+      ]
+    }
   ],
   "historical_scenarios": [
-    [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 10.0}}
-    ], [
-      {"node": "first_stage", "support": {}},
-      {"node": "second_stage", "support": {"d": 14.0}}
-    ]
+    {
+      "probability": 0.5,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 10.0}}
+      ]
+    }, {
+      "probability": 0.5,
+      "scenario": [
+        {"node": "first_stage", "support": {}},
+        {"node": "second_stage", "support": {"d": 14.0}}
+      ]
+    }
   ]
 }

--- a/sof.schema.json
+++ b/sof.schema.json
@@ -72,15 +72,21 @@
             "items": {
                 "$ref": "#/definitions/edge"
             }
+        },
+        "test_scenarios": {
+            "description": "Out-of-sample scenarios used to evaluate the policy.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/scenario"
+            }
+        },
+        "historical_scenarios": {
+            "description": "Optional scenarios used when building the problem. Allows modellers to experiment with different stochastic processes.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/scenario"
+            }
         }
-    },
-    "test_scenarios": {
-        "description": "Out-of-sample scenarios used to evaluate the policy.",
-        "$ref": "#/definitions/scenarios"
-    },
-    "historical_scenarios": {
-        "description": "Optional scenarios used when building the problem. Allows modellers to experiment with different stochastic processes.",
-        "$ref": "#/definitions/scenarios"
     },
     "definitions": {
         "edge": {
@@ -157,21 +163,28 @@
                 }
             }
         },
-        "scenarios": {
-            "type": "array",
-            "items": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": ["node", "support"],
-                    "properties": {
-                        "node": {
-                            "type": "string"
-                        },
-                        "support": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "number"
+        "scenario": {
+            "required": ["probability", "scenario"],
+            "properties": {
+                "probability": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "scenario": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["node", "support"],
+                        "properties": {
+                            "node": {
+                                "type": "string"
+                            },
+                            "support": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "number"
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes #11

I came to the conclusion that this is the correct thing to do because we may want the `test_scenarios` to be an enumeration of the in-sample scenarios with appropriate probabilities.