### PR TITLE
StochOptFormat version 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
   "version": {"major": 0, "minor": 2},
   "root": {
-    "name": "root",
     "state_variables": {
       "x": {"initial_value": 0.0}
     },
@@ -408,19 +407,15 @@ After the optional metadata keys, there are four required keys:
 
 - `version::Object`
 
-  An object describing the minimum version of MathOptFormat needed to parse
+  An object describing the minimum version of StochOptFormat needed to parse
   the file. This is included to safeguard against later revisions. It contains
-  two keys: `major` and `minor`. These keys should be interpreted using
+  two required keys: `major` and `minor`. These keys should be interpreted using
   [SemVer](https://semver.org).
 
 - `root::Object`
 
-  An object describing the root node of the policy graph. It has two required
-  keys:
-
-  - `name::String`
-
-    A unique string name for the root node to distinguish it from other nodes.
+  An object describing the root node of the policy graph. It has the following
+  required keys:
 
   - `state_variables::Object`
 
@@ -441,8 +436,8 @@ After the optional metadata keys, there are four required keys:
 - `nodes::Object`
 
   An object mapping the name of each node of the policy graph (excluding the
-  root node) to an object describing the node. Each object has two required
-  keys:
+  root node) to an object describing the node. Each object has the following
+  required keys:
 
   - `subproblem::String`
 
@@ -503,7 +498,7 @@ After the optional metadata keys, there are four required keys:
 
     The subproblem corresponding to the node as a MathOptFormat object.
 
-There are also two optional keys.
+There are also two optional keys:
 
 - `validation_scenarios::List{Object}`
 
@@ -676,7 +671,7 @@ test scenarios drawn from the same distribution as the validation data.
 - Q: JSON seems too verbose.
 
   A: JSON files compress well. For example, for problems in the MIPLIB 2017
-  benchmark set, compressed MathOptFormat files are only 37% larger than their
+  benchmark set, compressed MathOptFormat files are only 19% larger than their
   compressed MPS equivalents [2].
 
 - Q: I want the uncertainty to be an objective/constraint coefficient.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ optimization problems called _StochOptFormat_, with the file extension
 For convenience, we sometimes abbreviate StochOptFormat to _SOF_.
 
 StochOptFormat is rigidly defined by the [JSON schema](http://JSON-schema.org)
-available at [`https://odow.github.io/StochOptFormat/sof.schema.json`](https://odow.github.io/StochOptFormat/sof.schema.json).
+available at [`https://odow.github.io/StochOptFormat/sof-latest.schema.json`](https://odow.github.io/StochOptFormat/sof-latest.schema.json).
+Other versions are also available in the [versions directory].
 
-The [examples directory] of the
-project's [Github page](https://github.com/odow/StochOptFormat) contains a
-pedagogical implementation of Benders decomposition for two stage stochastic
-programs in Julia and Python, along with a JSON file for the news-vendor problem
-discussed in this documentation. The code is intended to be a guide, rather than
-a state-of-the-art implementation.
+The [examples directory] of the project's [Github page](https://github.com/odow/StochOptFormat)
+contains a pedagogical implementation of Benders decomposition for two stage
+stochastic programs in Julia and Python, along with a JSON file for the
+news-vendor problem discussed in this documentation. The code is intended to be
+a guide, rather than a state-of-the-art implementation.
 
 **Authors**
 
@@ -258,7 +258,7 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
   "name": "newsvendor",
   "date": "2020-07-10",
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
-  "version": {"major": 0, "minor": 1},
+  "version": {"major": 0, "minor": 2},
   "root": {
     "name": "root",
     "state_variables": {
@@ -734,6 +734,7 @@ test scenarios drawn from the same distribution as the validation data.
   [doi: 10.1002/9780470400531.eorms0411](https://doi.org/10.1002/9780470400531.eorms0411)
 
 [examples directory]: https://github.com/odow/StochOptFormat/tree/master/examples
+[versions directory]: https://github.com/odow/StochOptFormat/tree/master/versions
 [JuMP]: https://jump.dev
 [PuLP]: https://coin-or.github.io/pulp/
 [SDDP.jl]: https://odow.github.io/SDDP.jl/latest

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ multistage stochastic programs. StochOptFormat is a serialization of this data
 structure into the JSON file format, hence allowing easy access from almost all
 major computer languages.
 
-StochOptFormat is inspired by our work on [JuMP] and [SDDP.jl]. However, it is 
-not exclusive to Julia or stochastic dual dynamic programming. For example, this 
-format makes it possible to read multistage stochastic programming problems into 
+StochOptFormat is inspired by our work on [JuMP] and [SDDP.jl]. However, it is
+not exclusive to Julia or stochastic dual dynamic programming. For example, this
+format makes it possible to read multistage stochastic programming problems into
 Python and solve them with the progressive hedging library [PySP](https://pyomo.readthedocs.io/en/stable/modeling_extensions/pysp.html).
 We have not implemented the code yet because this is not our area of expertise.
 
@@ -100,22 +100,22 @@ In creating StochOptFormat, we wanted to achieve the following:
   (Spoiler alert: it is not the first stage decision. See
   [Problems, policies, and algorithms](#problems-policies-and-algorithms).)
 
-Equally important as the things that we set out to do, is the things that we did
-_not_ set out to do.
+Equally important as the things that we set out to do, are the things that we
+did _not_ set out to do.
 
   - We did not try to incorporate chance constraints.
   - We did not try to incorporate continuous random variables.
   - We did not try to incorporate decision-hazard nodes.
-  
-Finally, StochOptFormat is not an algebraic modeling language for stochastic 
+
+Finally, StochOptFormat is not an algebraic modeling language for stochastic
 programming. Instead, it is an instance format [5].
 
-You should not write StochOptFormat files by hand. Nor should you need to 
+You should not write StochOptFormat files by hand. Nor should you need to
 consider the exact layout of the file when formulating your model. The analog is
-the MPS file format. No one writes MPS files by hand, and most people are 
-probably unaware of the exact structure and syntax of an MPS file. Instead, we 
-use high-level algebraic modeling languages like [JuMP] to build models, and we 
-expect our solvers to handle the difficulty of reading and writing the MPS 
+the MPS file format. No one writes MPS files by hand, and most people are
+probably unaware of the exact structure and syntax of an MPS file. Instead, we
+use high-level algebraic modeling languages like [JuMP] to build models, and we
+expect our solvers to handle the difficulty of reading and writing the MPS
 files.
 
 ## Example
@@ -267,6 +267,23 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
   },
   "nodes": {
     "first_stage": {
+      "subproblem": "first_stage_subproblem",
+      "realizations": []
+    },
+    "second_stage": {
+      "subproblem": "second_stage_subproblem",
+      "realizations": [
+        {"probability": 0.4, "support": {"d": 10.0}},
+        {"probability": 0.6, "support": {"d": 14.0}}
+      ]
+    }
+  },
+  "edges": [
+    {"from": "root", "to": "first_stage", "probability": 1.0},
+    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
+  ],
+  "subproblems": {
+    "first_stage_subproblem": {
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
@@ -286,10 +303,9 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
           "function": {"head": "SingleVariable", "variable": "x_out"},
           "set": {"head": "GreaterThan", "lower": 0.0}
         }]
-      },
-      "realizations": []
+      }
     },
-    "second_stage": {
+    "second_stage_subproblem": {
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
@@ -331,18 +347,10 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
           "function": {"head": "SingleVariable", "variable": "u"},
           "set": {"head": "GreaterThan", "lower": 0.0}
         }]
-      },
-      "realizations": [
-        {"probability": 0.4, "support": {"d": 10.0}},
-        {"probability": 0.6, "support": {"d": 14.0}}
-      ]
+      }
     }
   },
-  "edges": [
-    {"from": "root", "to": "first_stage", "probability": 1.0},
-    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
-  ],
-  "test_scenarios": [
+  "validation_scenarios": [
     {
       "probability": 0.4,
       "scenario": [
@@ -424,33 +432,14 @@ After the optional metadata keys, there are five required keys:
 - `nodes::Object`
 
   An object mapping the name of each node of the policy graph (excluding the
-  root node) to an object describing the node. Each object has four required
+  root node) to an object describing the node. Each object has two required
   keys:
 
-  - `state_variables::Object`
+  - `subproblem::String`
 
-    An object that maps the name of each state variable (as defined in the root
-    node) to an object describing the incoming and outgoing state variables in
-    the subproblem. Each object has two required keys:
-
-    - `in::String`
-
-      The name of the variable representing the incoming state variable in the
-      subproblem.
-
-    - `out::String`
-
-      The name of the variable representing the outgoing state variable in the
-      subproblem.
-
-  - `random_variables::List{String}`
-
-    A list of strings describing the name of each random variable in the
-    subproblem.
-
-  - `subproblem::Object`
-
-    The subproblem corresponding to the node as a MathOptFormat object.
+    The name of the subproblem to use from the `subproblems` object. Multiple
+    nodes can refer to the same subproblem to reduce redundancy if they share
+    the same structural form.
 
   - `realizations::List{Object}`
 
@@ -486,9 +475,41 @@ After the optional metadata keys, there are five required keys:
 
     The nominal probability of transitioning from node `from` to node `to`.
 
-- `test_scenarios::List{Object}`
+- `subproblems::Object`
 
-  Scenarios to be used to evaluate a policy. `test_scenarios` is a list,
+  An object that stores the collection of subproblems in the policy graph. Each
+  object has three required keys:
+
+  - `state_variables::Object`
+
+    An object that maps the name of each state variable (as defined in the root
+    node) to an object describing the incoming and outgoing state variables in
+    the subproblem. Each object has two required keys:
+
+    - `in::String`
+
+      The name of the variable representing the incoming state variable in the
+      subproblem.
+
+    - `out::String`
+
+      The name of the variable representing the outgoing state variable in the
+      subproblem.
+
+  - `random_variables::List{String}`
+
+    A list of strings describing the name of each random variable in the
+    subproblem.
+
+  - `subproblem::Object`
+
+    The subproblem corresponding to the node as a MathOptFormat object.
+
+There are also two optional keys.
+
+- `validation_scenarios::List{Object}`
+
+  Scenarios to be used to evaluate a policy. `validation_scenarios` is a list,
   containing one element for each scenario in the test set. Each element is an
   object with two fields: `probability::Number` and `scenario::List{Object}`.
   The `probability` gives the nominal probability associated with the scenario.
@@ -500,16 +521,16 @@ After the optional metadata keys, there are five required keys:
   policy is a larger topic, so we expand on it in the section
   [Problems, policies, and algorithms](#problems-policies-and-algorithms).
 
-There is also an optional key, `historical_scenarios::List{Object}`. The
-value of the key is identical to `test_scenarios`, except that these scenarios
-should be any historical data that was used when first constructing the problem.
-This allows modellers to experiment with different representations of the
-underlying stochastic process.
+- `historical_scenarios::List{Object}`.
 
-In our example, the second stage realizations have probilities of 0.6 and 0.4.
-However, there are two `historical_scenarios`, each with probability 0.5, so one
-may infer that another reasonable model would be to give the node realizations
-probabilities of 0.5 and 0.5.
+  The value of this key is identical to `validation_scenarios`, except that
+  these scenarios should be any historical data that was used when first
+  constructing the problem. This allows modellers to experiment with different representations of the underlying stochastic process.
+
+  In our example, the second stage realizations have probilities of 0.6 and 0.4.
+  However, there are two `historical_scenarios`, each with probability 0.5, so
+  one may infer that another reasonable model would be to give the node
+  realizations probabilities of 0.5 and 0.5.
 
 Providing both `realizations` and `historical_scenarios` allows us to to do two
 things:
@@ -569,7 +590,7 @@ of scenarios over which it should be evaluated is so large as to be intractable.
 
 To overcome these two issues, we evaluate the policy by means of an
 _out-of-sample_ simulation on a finite discrete set of scenarios provided in the
-`test_scenarios` key of a StochOptFormat file.
+`validation_scenarios` key of a StochOptFormat file.
 
 Solution algorithms should evaluate their policy on each of these scenarios and
 report the following for each node in each scenario:
@@ -589,12 +610,11 @@ problem, but it does not solve the user's risk perference problem. However, with
 the above mentioned report, it is possible to evaluate multiple metrics of the
 resulting policy, such as expected objective values, and various quantiles.
 
-We envisage that any benchmark library would provide algorithm rankings based on
-a number of difference risk measures (e.g., expectation, worst-case, variance),
-so that users can select the one that most closely resembles theirs.
+Be aware not to over-fit the policy to the validation data!
 
-We emphasize that the _out-of-sample_ analysis is deeply tied with the actual
-application of stochastic optimization in real life.
+In the future, we hope to start a competition for solving multistage programs.
+This competition would evaluate the performance of policies on a withheld set of
+test scenarios drawn from the same distribution as the validation data.
 
 ## FAQ
 
@@ -617,7 +637,7 @@ application of stochastic optimization in real life.
 
 - Q: You don't expect me to write these by hand do you?
 
-  A: No. We expect high-level libraries like [SDDP.jl] to do the reading and 
+  A: No. We expect high-level libraries like [SDDP.jl] to do the reading and
   writing for you.
 
 - Q: What happened to SMPS?
@@ -688,7 +708,7 @@ application of stochastic optimization in real life.
 - Pedagogical Julia code for solving two-stage stochastic linear programs using
   Benders decomposition and [JuMP] is available in the [examples directory].
 
-- Experimental support for reading and writing StochOptFormat files is available 
+- Experimental support for reading and writing StochOptFormat files is available
   in the [SDDP.jl] libary.
 
 ## References
@@ -698,21 +718,21 @@ application of stochastic optimization in real life.
   [doi: 10.1002/net.21932](https://onlinelibrary.wiley.com/doi/full/10.1002/net.21932)
   [[preprint]](http://www.optimization-online.org/DB_HTML/2018/11/6914.html)
 
-[2] Legat, B., Dowson, O., Garcia, J.D. and Lubin, M. (2020). MathOptInterface: 
+[2] Legat, B., Dowson, O., Garcia, J.D. and Lubin, M. (2020). MathOptInterface:
   a data structure for mathematical optimization problems.
   [[preprint]](http://www.optimization-online.org/DB_HTML/2020/02/7609.html)
   [[repository]](https://github.com/jump-dev/MathOptFormat)
 
-[3] Fourer, R., Gassmann, H.I., Ma, J. and Martin, R.K. (2009). An XML-based schema for 
+[3] Fourer, R., Gassmann, H.I., Ma, J. and Martin, R.K. (2009). An XML-based schema for
   stochastic programs. _Ann Oper Res_, 166, 313-337.
   [doi: 10.1007/s10479-008-0419-x](https://link.springer.com/content/pdf/10.1007/s10479-008-0419-x.pdf)
 
 [4] Gassmann, H.I. and Kristjánsson, B. (2008). The SMPS format explained. _IMA
   Journal of Management Mathematics_, 19(4), 347-377. [doi: 10.1093/imaman/dpm007](http://maximal.net/resources/GassmannKristjansson_dpm007v1.pdf)
 
-[5] Gassmann, H.I., Ma, J. and Martin, R.K. (2011). Instance Formats for Mathematical 
-  Optimization Models. In _Wiley Encyclopedia of Operations Research and Management 
-  Science_ (eds J.J. Cochran, L.A. Cox, P. Keskinocak, J.P. Kharoufeh and J.C. Smith). 
+[5] Gassmann, H.I., Ma, J. and Martin, R.K. (2011). Instance Formats for Mathematical
+  Optimization Models. In _Wiley Encyclopedia of Operations Research and Management
+  Science_ (eds J.J. Cochran, L.A. Cox, P. Keskinocak, J.P. Kharoufeh and J.C. Smith).
   [doi: 10.1002/9780470400531.eorms0411](https://doi.org/10.1002/9780470400531.eorms0411)
 
 [examples directory]: https://github.com/odow/StochOptFormat/tree/master/examples

--- a/README.md
+++ b/README.md
@@ -263,25 +263,28 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
     "name": "root",
     "state_variables": {
       "x": {"initial_value": 0.0}
-    }
+    },
+    "successors": [
+      {"node": "first_stage", "probability": 1.0}
+    ]
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
-      "realizations": []
+      "realizations": [],
+      "successors": [
+        {"node": "second_stage", "probability": 1.0}
+      ]
     },
     "second_stage": {
       "subproblem": "second_stage_subproblem",
       "realizations": [
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
-      ]
+      ],
+      "successors": []
     }
   },
-  "edges": [
-    {"from": "root", "to": "first_stage", "probability": 1.0},
-    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
-  ],
   "subproblems": {
     "first_stage_subproblem": {
       "state_variables": {
@@ -401,7 +404,7 @@ Note: In the following, `name::String` means that the key of an object is `name`
 and the value should be of type `String`. `::List{Object}` means that the type
 is a `List`, and elements of the list are `Object`s.
 
-After the optional metadata keys, there are five required keys:
+After the optional metadata keys, there are four required keys:
 
 - `version::Object`
 
@@ -428,6 +431,12 @@ After the optional metadata keys, there are five required keys:
     - `initial_value::Number`
 
       The value of the state variable at the root node.
+
+  - `successors::List{Object}`
+
+    The list of edges exiting the root node. Each object has two keys,
+    `node::String` and `probability::Number` which give the probability of
+    transitioning from the root node to `node`.
 
 - `nodes::Object`
 
@@ -458,22 +467,11 @@ After the optional metadata keys, there are five required keys:
       `random_variables`, and the values are the value of the random variable in
       that realization.
 
-- `edges::List{Object}`
+  - `successors::List{Object}`
 
-  A list of objects with one element for each edge in the policy graph. Each
-  object has three required keys:
-
-  - `from::String`
-
-    The name of the node that the edge exits.
-
-  - `to::String`
-
-    The name of the node that the edge enters. This cannot be the root node.
-
-  - `probability::Number`
-
-    The nominal probability of transitioning from node `from` to node `to`.
+    The list of edges exiting the node. Each object has two keys, `node::String`
+    and `probability::Number` which give the probability of transitioning from
+    the current node to `node`.
 
 - `subproblems::Object`
 
@@ -625,9 +623,9 @@ test scenarios drawn from the same distribution as the validation data.
   our format requires T subproblems, a list of the state variables, and a
   sequence of edges. Of those things, only the list of edges would be
   superfluous in a purely T-stage format. So, for the sake of a list of objects
-  like `{"from": "1", "to": "2", "probability": 1}`, we get a format that
-  trivially extends to infinite horizon problems and problems with a stochastic
-  process that is not stagewise independent.
+  like `{"node": "1", "probability": 1}`, we get a format that trivially extends
+  to infinite horizon problems and problems with a stochastic process that is
+  not stagewise independent.
 
 - Q: MathOptFormat is too complicated. Why can't we use LP or MPS files?
 

--- a/examples/lang-julia/TwoStageBenders.jl
+++ b/examples/lang-julia/TwoStageBenders.jl
@@ -89,20 +89,16 @@ end
 
 function _get_stage_names(data::Dict)
     @assert length(data["nodes"]) == 2
-    @assert length(data["edges"]) == 2
-    edge_1, edge_2 = data["edges"]
+    @assert length(data["root"]["successors"]) == 1
+    edge_1 = data["root"]["successors"][1]
     @assert edge_1["probability"] == 1.0
+    first_node = edge_1["node"]
+    @assert length(data["nodes"][first_node]["successors"]) == 1
+    edge_2 = data["nodes"][first_node]["successors"][1]
     @assert edge_2["probability"] == 1.0
-    first, second = "", ""
-    if edge_1["from"] == data["root"]["name"]
-        @assert edge_2["from"] != data["root"]["name"]
-        @assert edge_1["to"] == edge_2["from"]
-        return edge_1["to"], edge_2["to"]
-    else
-        @assert edge_2["from"] == data["root"]["name"]
-        @assert edge_2["to"] == edge_1["from"]
-        return edge_2["to"], edge_1["to"]
-    end
+    second_node = edge_2["node"]
+    @assert length(data["nodes"][second_node]["successors"]) == 0
+    return first_node, second_node
 end
 
 function _mathoptformat_to_jump(data, name)

--- a/examples/lang-julia/TwoStageBenders.jl
+++ b/examples/lang-julia/TwoStageBenders.jl
@@ -27,7 +27,7 @@ import Printf
 import SHA
 
 const SCHEMA_FILENAME =
-    joinpath(dirname(dirname(@__DIR__)), "sof.schema.json")
+    joinpath(dirname(dirname(@__DIR__)), "sof-latest.schema.json")
 
 const RESULT_SCHEMA_FILENAME =
     joinpath(dirname(dirname(@__DIR__)), "sof_result.schema.json")
@@ -56,7 +56,7 @@ function TwoStageProblem(filename::String; validate::Bool = true)
         _validate(data; schema_filename = SCHEMA_FILENAME)
     end
     @assert(data["version"]["major"] == 0)
-    @assert(data["version"]["minor"] == 1)
+    @assert(data["version"]["minor"] == 2)
     first, second = _get_stage_names(data)
     problem = TwoStageProblem(
         sha_256,

--- a/examples/lang-python/TwoStageBenders.py
+++ b/examples/lang-python/TwoStageBenders.py
@@ -88,7 +88,7 @@ class TwoStageProblem:
 
     def evaluate(self, scenarios = None, filename = None):
         if scenarios is None:
-            scenarios = self.data['test_scenarios']
+            scenarios = self.data['validation_scenarios']
         solutions = []
         for s_dict in scenarios:
             scenario = s_dict['scenario']
@@ -139,7 +139,8 @@ class TwoStageProblem:
 
     def _mathoptformat_to_pulp(self, name):
         node = self.data['nodes'][name]
-        sp = node['subproblem']
+        subproblem = self.data['subproblems'][node['subproblem']]
+        sp = subproblem['subproblem']
         # Create the problem
         sense = LpMaximize if sp['objective']['sense'] == 'max' else LpMinimize
         prob = LpProblem(name, sense)
@@ -194,7 +195,7 @@ class TwoStageProblem:
         return {
             'subproblem': prob,
             'vars': vars,
-            'state_variables': node['state_variables'],
+            'state_variables': subproblem['state_variables'],
             'realizations': node['realizations'],
         }
 

--- a/examples/lang-python/TwoStageBenders.py
+++ b/examples/lang-python/TwoStageBenders.py
@@ -123,19 +123,16 @@ class TwoStageProblem:
     def _get_stage_names(self):
         data = self.data
         assert(len(data['nodes']) == 2)
-        assert(len(data['edges']) == 2)
-        edge_1, edge_2 = data['edges']
+        assert(len(data['root']['successors']) == 1)
+        edge_1 = data['root']['successors'][0]
         assert(edge_1['probability'] == 1.0)
+        first_node = edge_1['node']
+        assert(len(data['nodes'][first_node]['successors']) == 1)
+        edge_2 = data['nodes'][first_node]['successors'][0]
         assert(edge_2['probability'] == 1.0)
-        first, second = '', ''
-        if edge_1['from'] == data['root']['name']:
-            assert(edge_2['from'] != data['root']['name'])
-            assert(edge_1['to'] == edge_2['from'])
-            return edge_1['to'], edge_2['to']
-        else:
-            assert(edge_2['from'] == data['root']['name'])
-            assert(edge_2['to'] == edge_1['from'])
-            return edge_2['to'], edge_1['to']
+        second_node = edge_2['node']
+        assert(len(data['nodes'][second_node]['successors']) == 0)
+        return first_node, second_node
 
     def _mathoptformat_to_pulp(self, name):
         node = self.data['nodes'][name]

--- a/examples/lang-python/TwoStageBenders.py
+++ b/examples/lang-python/TwoStageBenders.py
@@ -29,7 +29,7 @@ class TwoStageProblem:
     _dir = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     )
-    schema_filename = os.path.join(_dir, 'sof.schema.json')
+    schema_filename = os.path.join(_dir, 'sof-latest.schema.json')
     result_schema_filename = os.path.join(_dir, 'sof_result.schema.json')
 
     def __init__(self, filename, validate = True):

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -3,7 +3,7 @@
   "name": "newsvendor",
   "date": "2020-07-10",
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
-  "version": {"major": 0, "minor": 1},
+  "version": {"major": 0, "minor": 2},
   "root": {
     "name": "root",
     "state_variables": {

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -5,7 +5,6 @@
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
   "version": {"major": 0, "minor": 2},
   "root": {
-    "name": "root",
     "state_variables": {
       "x": {"initial_value": 0.0}
     },

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -8,25 +8,28 @@
     "name": "root",
     "state_variables": {
       "x": {"initial_value": 0.0}
-    }
+    },
+    "successors": [
+      {"node": "first_stage", "probability": 1.0}
+    ]
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
-      "realizations": []
+      "realizations": [],
+      "successors": [
+        {"node": "second_stage", "probability": 1.0}
+      ]
     },
     "second_stage": {
       "subproblem": "second_stage_subproblem",
       "realizations": [
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
-      ]
+      ],
+      "successors": []
     }
   },
-  "edges": [
-    {"from": "root", "to": "first_stage", "probability": 1.0},
-    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
-  ],
   "subproblems": {
     "first_stage_subproblem": {
       "state_variables": {

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -12,6 +12,23 @@
   },
   "nodes": {
     "first_stage": {
+      "subproblem": "first_stage_subproblem",
+      "realizations": []
+    },
+    "second_stage": {
+      "subproblem": "second_stage_subproblem",
+      "realizations": [
+        {"probability": 0.4, "support": {"d": 10.0}},
+        {"probability": 0.6, "support": {"d": 14.0}}
+      ]
+    }
+  },
+  "edges": [
+    {"from": "root", "to": "first_stage", "probability": 1.0},
+    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
+  ],
+  "subproblems": {
+    "first_stage_subproblem": {
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
@@ -31,10 +48,9 @@
           "function": {"head": "SingleVariable", "variable": "x_out"},
           "set": {"head": "GreaterThan", "lower": 0.0}
         }]
-      },
-      "realizations": []
+      }
     },
-    "second_stage": {
+    "second_stage_subproblem": {
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
@@ -76,18 +92,10 @@
           "function": {"head": "SingleVariable", "variable": "u"},
           "set": {"head": "GreaterThan", "lower": 0.0}
         }]
-      },
-      "realizations": [
-        {"probability": 0.4, "support": {"d": 10.0}},
-        {"probability": 0.6, "support": {"d": 14.0}}
-      ]
+      }
     }
   },
-  "edges": [
-    {"from": "root", "to": "first_stage", "probability": 1.0},
-    {"from": "first_stage", "to": "second_stage", "probability": 1.0}
-  ],
-  "test_scenarios": [
+  "validation_scenarios": [
     {
       "probability": 0.4,
       "scenario": [

--- a/sof-latest.schema.json
+++ b/sof-latest.schema.json
@@ -37,12 +37,8 @@
         "root": {
             "description": "An object for the root node.",
             "type": "object",
-            "required": ["name", "state_variables", "successors"],
+            "required": ["state_variables", "successors"],
             "properties": {
-                "name": {
-                    "description": "The name of the root node, to be used in `edges`.",
-                    "type": "string"
-                },
                 "state_variables": {
                     "description": "A vector of state variables.",
                     "type": "object",

--- a/sof-latest.schema.json
+++ b/sof-latest.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://odow.github.io/StochOptFormat/sof.schema.json",
+    "$id": "https://odow.github.io/StochOptFormat/sof-latest.schema.json",
     "title": "The schema for a policy graph representation of a multistage stochastic program",
     "type": "object",
     "required": ["version", "root", "nodes", "subproblems"],
@@ -11,7 +11,7 @@
             "required": ["minor", "major"],
             "properties": {
                 "minor": {
-                    "const": 1
+                    "const": 2
                 },
                 "major": {
                     "const": 0

--- a/sof.schema.json
+++ b/sof.schema.json
@@ -3,7 +3,7 @@
     "$id": "https://odow.github.io/StochOptFormat/sof.schema.json",
     "title": "The schema for a policy graph representation of a multistage stochastic program",
     "type": "object",
-    "required": ["version", "root", "nodes", "edges", "test_scenarios"],
+    "required": ["version", "root", "nodes", "edges", "subproblems"],
     "properties": {
         "version": {
             "description": "The version of StochOptFormat that this schema validates against.",
@@ -63,7 +63,33 @@
             "description": "An object containing the nodes in the policy graph.",
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/definitions/node"
+                "type": "object",
+                "required": ["realizations", "subproblem"],
+                "properties": {
+                    "realizations": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["probability", "support"],
+                            "properties": {
+                                "probability": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                },
+                                "support": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "number"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "subproblem": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "edges": {
@@ -73,7 +99,14 @@
                 "$ref": "#/definitions/edge"
             }
         },
-        "test_scenarios": {
+        "subproblems": {
+            "description": "An object of subproblems. Multiple nodes can point to the same subproblem.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/subproblem"
+            }
+        },
+        "validation_scenarios": {
             "description": "Out-of-sample scenarios used to evaluate the policy.",
             "type": "array",
             "items": {
@@ -107,12 +140,10 @@
                 }
             }
         },
-        "node": {
-            "description": "A node in the policy graph.",
+        "subproblem": {
+            "description": "A subproblem in the policy graph.",
             "type": "object",
-            "required": [
-                "state_variables", "random_variables", "subproblem", "realizations"
-            ],
+            "required": ["state_variables", "random_variables", "subproblem"],
             "properties": {
                 "state_variables": {
                     "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
@@ -140,26 +171,6 @@
                 "subproblem": {
                     "description": "The subproblem in MathOptFormat.",
                     "$ref": "https://jump.dev/MathOptFormat/mof.0.4.schema.json"
-                },
-                "realizations": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["probability", "support"],
-                        "properties": {
-                            "probability": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1
-                            },
-                            "support": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "number"
-                                }
-                            }
-                        }
-                    }
                 }
             }
         },

--- a/sof.schema.json
+++ b/sof.schema.json
@@ -3,7 +3,7 @@
     "$id": "https://odow.github.io/StochOptFormat/sof.schema.json",
     "title": "The schema for a policy graph representation of a multistage stochastic program",
     "type": "object",
-    "required": ["version", "root", "nodes", "edges", "subproblems"],
+    "required": ["version", "root", "nodes", "subproblems"],
     "properties": {
         "version": {
             "description": "The version of StochOptFormat that this schema validates against.",
@@ -37,7 +37,7 @@
         "root": {
             "description": "An object for the root node.",
             "type": "object",
-            "required": ["name", "state_variables"],
+            "required": ["name", "state_variables", "successors"],
             "properties": {
                 "name": {
                     "description": "The name of the root node, to be used in `edges`.",
@@ -56,6 +56,23 @@
                             }
                         }
                     }
+                },
+                "successors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["node", "probability"],
+                        "properties": {
+                            "node": {
+                                "type": "string"
+                            },
+                            "probability": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -64,8 +81,11 @@
             "type": "object",
             "additionalProperties": {
                 "type": "object",
-                "required": ["realizations", "subproblem"],
+                "required": ["subproblem", "realizations", "successors"],
                 "properties": {
+                    "subproblem": {
+                        "type": "string"
+                    },
                     "realizations": {
                         "type": "array",
                         "items": {
@@ -86,8 +106,22 @@
                             }
                         }
                     },
-                    "subproblem": {
-                        "type": "string"
+                    "successors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["node", "probability"],
+                            "properties": {
+                                "node": {
+                                    "type": "string"
+                                },
+                                "probability": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Based on discussions with @loehndorf

- Subproblems are now stored in a separate key from `nodes` so that multiple nodes can refer to the same subproblem (e.g., every Markov state at a particular stage, or all subproblems excluding the first and last stages, i.e., `t = 2, ..., T-1`.

- `test_scenarios` renamed `validation_scenarios`. We won't be hosting or ranking best solutions based on the test scenarios. Instead, we could hold competitions where policies are evaluated on withheld test-scenarios. Validation scenarios are still provided for users to evaluate the out-of-sample performance, although they may over-fit, and to encourage them to develop algorithms that can handle realizations that are not contained in the historical or in-sample distributions. That means for now we are going to side-step the question of how to compare two policies and leave that to future work. Just being able to share models is a good step forward.

- [x] Potential decision: should we merge `edges` into `nodes` in the form of `successors`? I think @loehndorf does it this way.