### PR TITLE
Simplify successors

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,17 +263,13 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
     "state_variables": {
       "x": {"initial_value": 0.0}
     },
-    "successors": [
-      {"node": "first_stage", "probability": 1.0}
-    ]
+    "successors": {"first_stage": 1.0}
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
       "realizations": [],
-      "successors": [
-        {"node": "second_stage", "probability": 1.0}
-      ]
+      "successors": {"second_stage": 1.0}
     },
     "second_stage": {
       "subproblem": "second_stage_subproblem",
@@ -281,7 +277,7 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
       ],
-      "successors": []
+      "successors": {}
     }
   },
   "subproblems": {
@@ -427,11 +423,10 @@ After the optional metadata keys, there are four required keys:
 
       The value of the state variable at the root node.
 
-  - `successors::List{Object}`
+  - `successors::Object`
 
-    The list of edges exiting the root node. Each object has two keys,
-    `node::String` and `probability::Number` which give the probability of
-    transitioning from the root node to `node`.
+    An object in which the keys correspond to nodes and the values correspond to
+    the probability of transitioning from the root node to the key node.
 
 - `nodes::Object`
 
@@ -462,11 +457,10 @@ After the optional metadata keys, there are four required keys:
       `random_variables`, and the values are the value of the random variable in
       that realization.
 
-  - `successors::List{Object}`
+  - `successors::Object`
 
-    The list of edges exiting the node. Each object has two keys, `node::String`
-    and `probability::Number` which give the probability of transitioning from
-    the current node to `node`.
+    An object in which the keys correspond to nodes and the values correspond to
+    the probability of transitioning from the current node to the key node.
 
 - `subproblems::Object`
 

--- a/examples/lang-julia/TwoStageBenders.jl
+++ b/examples/lang-julia/TwoStageBenders.jl
@@ -90,13 +90,12 @@ end
 function _get_stage_names(data::Dict)
     @assert length(data["nodes"]) == 2
     @assert length(data["root"]["successors"]) == 1
-    edge_1 = data["root"]["successors"][1]
-    @assert edge_1["probability"] == 1.0
-    first_node = edge_1["node"]
-    @assert length(data["nodes"][first_node]["successors"]) == 1
-    edge_2 = data["nodes"][first_node]["successors"][1]
-    @assert edge_2["probability"] == 1.0
-    second_node = edge_2["node"]
+    first_node, probability = first(data["root"]["successors"])
+    @assert probability == 1.0
+    successors = data["nodes"][first_node]["successors"]
+    @assert length(successors) == 1
+    second_node, probability = first(successors)
+    @assert probability == 1.0
     @assert length(data["nodes"][second_node]["successors"]) == 0
     return first_node, second_node
 end

--- a/examples/lang-python/TwoStageBenders.py
+++ b/examples/lang-python/TwoStageBenders.py
@@ -124,13 +124,12 @@ class TwoStageProblem:
         data = self.data
         assert(len(data['nodes']) == 2)
         assert(len(data['root']['successors']) == 1)
-        edge_1 = data['root']['successors'][0]
-        assert(edge_1['probability'] == 1.0)
-        first_node = edge_1['node']
-        assert(len(data['nodes'][first_node]['successors']) == 1)
-        edge_2 = data['nodes'][first_node]['successors'][0]
-        assert(edge_2['probability'] == 1.0)
-        second_node = edge_2['node']
+        (first_node, probability) = next(iter(data['root']['successors'].items()))
+        assert(probability == 1.0)
+        successors = data['nodes'][first_node]['successors']
+        assert(len(successors) == 1)
+        (second_node, probability) = next(iter(successors.items()))
+        assert(probability == 1.0)
         assert(len(data['nodes'][second_node]['successors']) == 0)
         return first_node, second_node
 

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -8,17 +8,13 @@
     "state_variables": {
       "x": {"initial_value": 0.0}
     },
-    "successors": [
-      {"node": "first_stage", "probability": 1.0}
-    ]
+    "successors": {"first_stage": 1.0}
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
       "realizations": [],
-      "successors": [
-        {"node": "second_stage", "probability": 1.0}
-      ]
+      "successors": {"second_stage": 1.0}
     },
     "second_stage": {
       "subproblem": "second_stage_subproblem",
@@ -26,7 +22,7 @@
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
       ],
-      "successors": []
+      "successors": {}
     }
   },
   "subproblems": {

--- a/sof-latest.schema.json
+++ b/sof-latest.schema.json
@@ -54,20 +54,11 @@
                     }
                 },
                 "successors": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["node", "probability"],
-                        "properties": {
-                            "node": {
-                                "type": "string"
-                            },
-                            "probability": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1
-                            }
-                        }
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
                     }
                 }
             }
@@ -103,20 +94,11 @@
                         }
                     },
                     "successors": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["node", "probability"],
-                            "properties": {
-                                "node": {
-                                    "type": "string"
-                                },
-                                "probability": {
-                                    "type": "number",
-                                    "minimum": 0,
-                                    "maximum": 1
-                                }
-                            }
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
                         }
                     }
                 }


### PR DESCRIPTION
No need to store a list of edges when an object will do. Also prevents the user from defining multiple edges between the same nodes.