### PR TITLE
StochOptFormat v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ optimization problems called _StochOptFormat_, with the file extension
 For convenience, we abbreviate StochOptFormat to _SOF_.
 
 StochOptFormat is defined by the [JSON schema](http://JSON-schema.org)
-[`https://odow.github.io/StochOptFormat/versions/sof-0.2.schema.json`](https://odow.github.io/StochOptFormat/versions/sof-0.2.schema.json).
+[`https://odow.github.io/StochOptFormat/versions/sof-0.3.schema.json`](https://odow.github.io/StochOptFormat/versions/sof-0.3.schema.json).
 
 _Note: StochOptFormat is in development. If you have suggestions or comments,
 please [open an issue](https://github.com/odow/StochOptFormat/issues/new)._
@@ -247,19 +247,16 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
 {
   "author": "Oscar Dowson",
   "name": "newsvendor",
-  "date": "2020-07-10",
+  "date": "2023-05-02",
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
-  "version": {"major": 0, "minor": 2},
+  "version": {"major": 0, "minor": 3},
   "root": {
-    "state_variables": {
-      "x": {"initial_value": 0.0}
-    },
+    "state_variables": {"x": 0.0},
     "successors": {"first_stage": 1.0}
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
-      "realizations": [],
       "successors": {"second_stage": 1.0}
     },
     "second_stage": {
@@ -267,8 +264,7 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
       "realizations": [
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
-      ],
-      "successors": {}
+      ]
     }
   },
   "subproblems": {
@@ -276,7 +272,6 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
-      "random_variables": [],
       "subproblem": {
         "version": {"major": 1, "minor": 2},
         "variables": [{"name": "x_in"}, {"name": "x_out"}],
@@ -341,13 +336,13 @@ Encoded in StochOptFormat, the newsvendor problem becomes:
   },
   "validation_scenarios": [
     [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 10.0}}
     ], [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 14.0}}
     ], [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 9.0}}
     ]
   ]
@@ -383,12 +378,8 @@ After the optional metadata keys, there are four required keys:
   - `state_variables::Object`
 
     An object describing the state variables in the problem. Each key is the
-    unique name of a state variable. The value is an object with one required
-    key:
-
-    - `initial_value::Number`
-
-      The value of the state variable at the root node.
+    unique name of a state variable. The initial value of the state variable at
+    the root node.
 
   - `successors::Object`
 
@@ -407,7 +398,7 @@ After the optional metadata keys, there are four required keys:
     nodes can refer to the same subproblem to reduce redundancy if they share
     the same structural form.
 
-  - `realizations::List{Object}`
+  - `realizations::List{Object}` (Optional)
 
     A list of objects describing the finite discrete realizations of the
     independent random variable in each node. Each object has two required keys:
@@ -423,7 +414,7 @@ After the optional metadata keys, there are four required keys:
       `random_variables`, and the values are the value of the random variable in
       that realization.
 
-  - `successors::Object`
+  - `successors::Object` (Optional)
 
     An object in which the keys correspond to nodes and the values correspond to
     the probability of transitioning from the current node to the key node.
@@ -449,7 +440,7 @@ After the optional metadata keys, there are four required keys:
       The name of the variable representing the outgoing state variable in the
       subproblem.
 
-  - `random_variables::List{String}`
+  - `random_variables::List{String}` (Optional)
 
     A list of strings describing the name of each random variable in the
     subproblem.
@@ -464,13 +455,20 @@ There is also an optional key:
 
   Scenarios to be used to evaluate a policy. `validation_scenarios` is a list,
   containing one element for each scenario in the test set. Each element is a
-  list of objects. Each object has two required nodes: `node::String` and
-  `support::Object`. `node` is the name of the node to visit, and `support` is
-  the realization of the random variable at that node. Note that `support` may
-  be an _out-of-sample_ realization, that is, one which is not contained in the
-  corresponding `realizations` field of the node. Testing a policy is a larger
-  topic, so we expand on it in the section
-  [Problems, policies, and algorithms](#problems-policies-and-algorithms).
+  list of objects. Each object has two required fields:
+
+   - `node::String`
+
+     The name of the node to visit.
+
+   - `support::Object` (Optional)
+
+     The realization of the random variable at that node. Note that `support`
+     may be an _out-of-sample_ realization, that is, one which is not contained
+     in the corresponding `realizations` field of the node.
+
+Testing a policy is a larger topic, so we expand on it in the next section,
+[Problems, policies, and algorithms](#problems-policies-and-algorithms).
 
 ## Problems, policies, and algorithms
 

--- a/examples/problems/news_vendor.sof.json
+++ b/examples/problems/news_vendor.sof.json
@@ -1,19 +1,16 @@
 {
   "author": "Oscar Dowson",
   "name": "newsvendor",
-  "date": "2020-07-10",
+  "date": "2023-05-02",
   "description": "A StochOptFormat implementation of the classical two-stage newsvendor problem.",
-  "version": {"major": 0, "minor": 2},
+  "version": {"major": 0, "minor": 3},
   "root": {
-    "state_variables": {
-      "x": {"initial_value": 0.0}
-    },
+    "state_variables": {"x": 0.0},
     "successors": {"first_stage": 1.0}
   },
   "nodes": {
     "first_stage": {
       "subproblem": "first_stage_subproblem",
-      "realizations": [],
       "successors": {"second_stage": 1.0}
     },
     "second_stage": {
@@ -21,8 +18,7 @@
       "realizations": [
         {"probability": 0.4, "support": {"d": 10.0}},
         {"probability": 0.6, "support": {"d": 14.0}}
-      ],
-      "successors": {}
+      ]
     }
   },
   "subproblems": {
@@ -30,7 +26,6 @@
       "state_variables": {
         "x": {"in": "x_in", "out": "x_out"}
       },
-      "random_variables": [],
       "subproblem": {
         "version": {"major": 1, "minor": 2},
         "variables": [{"name": "x_in"}, {"name": "x_out"}],
@@ -95,13 +90,13 @@
   },
   "validation_scenarios": [
     [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 10.0}}
     ], [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 14.0}}
     ], [
-      {"node": "first_stage", "support": {}},
+      {"node": "first_stage"},
       {"node": "second_stage", "support": {"d": 9.0}}
     ]
   ]

--- a/versions/sof-0.2.schema.json
+++ b/versions/sof-0.2.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://odow.github.io/StochOptFormat/sof-0.2.schema.json",
+    "$id": "https://odow.github.io/StochOptFormat/versions/sof-0.2.schema.json",
     "title": "The schema for a policy graph representation of a multistage stochastic program",
     "type": "object",
     "required": ["version", "root", "nodes", "subproblems"],
@@ -9,14 +9,7 @@
             "description": "The version of StochOptFormat that this schema validates against.",
             "type": "object",
             "required": ["minor", "major"],
-            "properties": {
-                "minor": {
-                    "const": 2
-                },
-                "major": {
-                    "const": 0
-                }
-            }
+            "properties": {"minor": {"const": 2}, "major": {"const": 0}}
         },
         "name": {
             "description": "The name of the problem.",
@@ -70,9 +63,7 @@
                 "type": "object",
                 "required": ["subproblem", "realizations", "successors"],
                 "properties": {
-                    "subproblem": {
-                        "type": "string"
-                    },
+                    "subproblem": {"type": "string"},
                     "realizations": {
                         "type": "array",
                         "items": {
@@ -86,9 +77,7 @@
                                 },
                                 "support": {
                                     "type": "object",
-                                    "additionalProperties": {
-                                        "type": "number"
-                                    }
+                                    "additionalProperties": {"type": "number"}
                                 }
                             }
                         }
@@ -104,18 +93,36 @@
                 }
             }
         },
-        "edges": {
-            "description": "An array of edges in the policy graph.",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/edge"
-            }
-        },
         "subproblems": {
             "description": "An object of subproblems. Multiple nodes can point to the same subproblem.",
             "type": "object",
             "additionalProperties": {
-                "$ref": "#/definitions/subproblem"
+                "description": "A subproblem in the policy graph.",
+                "type": "object",
+                "required": ["state_variables", "random_variables", "subproblem"],
+                "properties": {
+                    "state_variables": {
+                        "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": ["in", "out"],
+                            "properties": {
+                                "in": {"type": "string"},
+                                "out": {"type": "string"}
+                            }
+                        }
+                    },
+                    "random_variables": {
+                        "description": "An array containing the names of the random variables in the subproblem.",
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "subproblem": {
+                        "description": "The subproblem in MathOptFormat. MOF is backward compatible, so we support all v1.X versions.",
+                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.2.schema.json"
+                    }
+                }
             }
         },
         "validation_scenarios": {
@@ -127,76 +134,12 @@
                     "type": "object",
                     "required": ["node", "support"],
                     "properties": {
-                        "node": {
-                            "type": "string"
-                        },
+                        "node": {"type": "string"},
                         "support": {
                             "type": "object",
-                            "additionalProperties": {
-                                "type": "number"
-                            }
+                            "additionalProperties": {"type": "number"}
                         }
                     }
-                }
-            }
-        }
-    },
-    "definitions": {
-        "edge": {
-            "description": "An edge in the policy graph, describing a transition from node `from` to node `to` with probability `probability`.",
-            "type": "object",
-            "required": ["from", "to", "probability"],
-            "properties": {
-                "from": {
-                    "type": "string"
-                },
-                "to": {
-                    "type": "string"
-                },
-                "probability": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1
-                }
-            }
-        },
-        "subproblem": {
-            "description": "A subproblem in the policy graph.",
-            "type": "object",
-            "required": ["state_variables", "random_variables", "subproblem"],
-            "properties": {
-                "state_variables": {
-                    "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "object",
-                        "required": ["in", "out"],
-                        "properties": {
-                            "in": {
-                                "type": "string"
-                            },
-                            "out": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "random_variables": {
-                    "description": "An array containing the names of the random variables in the subproblem.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "subproblem": {
-                    "description": "The subproblem in MathOptFormat.",
-                    "oneOf": [{
-                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.0.schema.json"
-                    }, {
-                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.1.schema.json"
-                    }, {
-                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.2.schema.json"
-                    }]
                 }
             }
         }

--- a/versions/sof-0.2.schema.json
+++ b/versions/sof-0.2.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://odow.github.io/StochOptFormat/versions/sof-0.2.schema.json",
+    "$id": "https://odow.github.io/StochOptFormat/sof-0.2.schema.json",
     "title": "The schema for a policy graph representation of a multistage stochastic program",
     "type": "object",
     "required": ["version", "root", "nodes", "subproblems"],
@@ -9,7 +9,14 @@
             "description": "The version of StochOptFormat that this schema validates against.",
             "type": "object",
             "required": ["minor", "major"],
-            "properties": {"minor": {"const": 2}, "major": {"const": 0}}
+            "properties": {
+                "minor": {
+                    "const": 2
+                },
+                "major": {
+                    "const": 0
+                }
+            }
         },
         "name": {
             "description": "The name of the problem.",
@@ -63,7 +70,9 @@
                 "type": "object",
                 "required": ["subproblem", "realizations", "successors"],
                 "properties": {
-                    "subproblem": {"type": "string"},
+                    "subproblem": {
+                        "type": "string"
+                    },
                     "realizations": {
                         "type": "array",
                         "items": {
@@ -77,7 +86,9 @@
                                 },
                                 "support": {
                                     "type": "object",
-                                    "additionalProperties": {"type": "number"}
+                                    "additionalProperties": {
+                                        "type": "number"
+                                    }
                                 }
                             }
                         }
@@ -93,36 +104,18 @@
                 }
             }
         },
+        "edges": {
+            "description": "An array of edges in the policy graph.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/edge"
+            }
+        },
         "subproblems": {
             "description": "An object of subproblems. Multiple nodes can point to the same subproblem.",
             "type": "object",
             "additionalProperties": {
-                "description": "A subproblem in the policy graph.",
-                "type": "object",
-                "required": ["state_variables", "random_variables", "subproblem"],
-                "properties": {
-                    "state_variables": {
-                        "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "object",
-                            "required": ["in", "out"],
-                            "properties": {
-                                "in": {"type": "string"},
-                                "out": {"type": "string"}
-                            }
-                        }
-                    },
-                    "random_variables": {
-                        "description": "An array containing the names of the random variables in the subproblem.",
-                        "type": "array",
-                        "items": {"type": "string"}
-                    },
-                    "subproblem": {
-                        "description": "The subproblem in MathOptFormat. MOF is backward compatible, so we support all v1.X versions.",
-                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.2.schema.json"
-                    }
-                }
+                "$ref": "#/definitions/subproblem"
             }
         },
         "validation_scenarios": {
@@ -134,12 +127,76 @@
                     "type": "object",
                     "required": ["node", "support"],
                     "properties": {
-                        "node": {"type": "string"},
+                        "node": {
+                            "type": "string"
+                        },
                         "support": {
                             "type": "object",
-                            "additionalProperties": {"type": "number"}
+                            "additionalProperties": {
+                                "type": "number"
+                            }
                         }
                     }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "edge": {
+            "description": "An edge in the policy graph, describing a transition from node `from` to node `to` with probability `probability`.",
+            "type": "object",
+            "required": ["from", "to", "probability"],
+            "properties": {
+                "from": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "string"
+                },
+                "probability": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "subproblem": {
+            "description": "A subproblem in the policy graph.",
+            "type": "object",
+            "required": ["state_variables", "random_variables", "subproblem"],
+            "properties": {
+                "state_variables": {
+                    "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "required": ["in", "out"],
+                        "properties": {
+                            "in": {
+                                "type": "string"
+                            },
+                            "out": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "random_variables": {
+                    "description": "An array containing the names of the random variables in the subproblem.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subproblem": {
+                    "description": "The subproblem in MathOptFormat.",
+                    "oneOf": [{
+                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.0.schema.json"
+                    }, {
+                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.1.schema.json"
+                    }, {
+                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.2.schema.json"
+                    }]
                 }
             }
         }

--- a/versions/sof-0.3.schema.json
+++ b/versions/sof-0.3.schema.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://json-schema.org/schema#",
+    "$id": "https://odow.github.io/StochOptFormat/versions/sof-0.3.schema.json",
+    "title": "The schema for a policy graph representation of a multistage stochastic program",
+    "type": "object",
+    "required": ["version", "root", "nodes", "subproblems"],
+    "properties": {
+        "version": {
+            "description": "The version of StochOptFormat that this schema validates against.",
+            "type": "object",
+            "required": ["minor", "major"],
+            "properties": {"minor": {"const": 3}, "major": {"const": 0}}
+        },
+        "name": {
+            "description": "The name of the problem.",
+            "type": "string"
+        },
+        "author": {
+            "description": "The author of the problem for citation purposes.",
+            "type": "string"
+        },
+        "date": {
+            "description": "The date that the problem was created [yyyy-mm-dd].",
+            "type": "string"
+        },
+        "description": {
+            "description": "A human-readable description of the problem.",
+            "type": "string"
+        },
+        "root": {
+            "description": "An object for the root node.",
+            "type": "object",
+            "required": ["state_variables", "successors"],
+            "properties": {
+                "state_variables": {
+                    "description": "A vector of state variables.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "description": "The value of the state variable at the root node.",
+                        "type": "number"
+                    }
+                },
+                "successors": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1
+                    }
+                }
+            }
+        },
+        "nodes": {
+            "description": "An object containing the nodes in the policy graph.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "required": ["subproblem"],
+                "properties": {
+                    "subproblem": {"type": "string"},
+                    "realizations": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["probability", "support"],
+                            "properties": {
+                                "probability": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                },
+                                "support": {
+                                    "type": "object",
+                                    "additionalProperties": {"type": "number"}
+                                }
+                            }
+                        }
+                    },
+                    "successors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            }
+        },
+        "subproblems": {
+            "description": "An object of subproblems. Multiple nodes can point to the same subproblem.",
+            "type": "object",
+            "additionalProperties": {
+                "description": "A subproblem in the policy graph.",
+                "type": "object",
+                "required": ["state_variables", "subproblem"],
+                "properties": {
+                    "state_variables": {
+                        "description": "An object that maps the name of the state variable to the incoming and outgoing state variables in the subproblem.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": ["in", "out"],
+                            "properties": {
+                                "in": {"type": "string"},
+                                "out": {"type": "string"}
+                            }
+                        }
+                    },
+                    "random_variables": {
+                        "description": "An array containing the names of the random variables in the subproblem.",
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "subproblem": {
+                        "description": "The subproblem in MathOptFormat. MOF is backward compatible, so we support all v1.X versions.",
+                        "$ref": "https://jump.dev/MathOptFormat/schemas/mof.1.2.schema.json"
+                    }
+                }
+            }
+        },
+        "validation_scenarios": {
+            "description": "Out-of-sample scenarios used to evaluate the policy.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["node"],
+                    "properties": {
+                        "node": {"type": "string"},
+                        "support": {
+                            "type": "object",
+                            "additionalProperties": {"type": "number"}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We're getting close to a v1.0.

Here's a few more simplifications now that I'm back in the groove.

### Removal of `initial_value`

There's no need for `"state_variables": {"x": {"initial_value": 0.0}},` when `"state_variables": {"x": 0.0}` will do.

### Empty realization/successors can be omitted

There's no need to force empty lists and objects like `"successors": {}`. Just drop the key. Same with `"realizations"` and `"support"`.

### MOF

We can use only the latest `v1.X` release because it's backwards compatible. We don't need to enumerate the versions that we support.

### Edges

For some reason, I didn't delete the schema fragments for `edge` and `edges`.